### PR TITLE
Only append api file when jsPath not specified

### DIFF
--- a/angular-file-upload.js
+++ b/angular-file-upload.js
@@ -27,6 +27,7 @@ if (!angularFileUpload.html5) {
 						break;
 					}
 				}
+        base += "FileAPI.min.js"
 			}
 
 			if (!window.FileAPI || FileAPI.staticPath == null) {
@@ -35,7 +36,7 @@ if (!angularFileUpload.html5) {
 				}
 			}
 	
-			script.setAttribute('src', base + 'FileAPI.min.js');
+			script.setAttribute('src', base);
 			document.getElementsByTagName('head')[0].appendChild(script);
 		}
 	})();


### PR DESCRIPTION
This fixes the problem of a double appended file name e.g.

http://foo.bar/FileAPI.jsFileAPI.js
