### PR TITLE
pass multiple files to upload

### DIFF
--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -35,7 +35,15 @@ angularFileUpload.service('$upload', ['$http', '$rootScope', function($http, $ro
 			}
 		}
 		config.transformRequest =  angular.identity;
-		formData.append(config.fileFormDataName || 'file', config.file, config.file.name);
+		
+		//multiple files
+		if (angular.isArray(config.file)) {
+	          angular.forEach(config.file, function(i, e) {
+	              formData.append(config.fileFormDataName || 'file', i, i.name);
+	          });
+	      	} else {
+	          formData.append(config.fileFormDataName || 'file', config.file, config.file.name);
+	      	}
 
 		formData['__setXHR_'] = function(xhr) {
 			config.__XHR = xhr;


### PR DESCRIPTION
Added a check to support multiple files passed to upload method. For browsers that support multiple files selection. I needed to pass multiple files to server instead of one file per request. Tested on Latest Chrome and IE9.
