### PR TITLE
Fixed TypeError: Cannot set property 'Content-Type' of undefined

### DIFF
--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -64,6 +64,7 @@ angularFileUpload.service('$upload', ['$http', '$rootScope', '$timeout', functio
 		return promise;
 	};
 	this.upload = function(config) {
+        config.headers = config.headers || {};
 		config.headers['Content-Type'] = undefined;
 		config.transformRequest = config.transformRequest || $http.defaults.transformRequest;
 		var formData = new FormData();


### PR DESCRIPTION
In the latest version of angular-file-upload while using `$upload.upload({ .. });` method
throws a _TypeError: Cannot set property 'Content-Type' of undefined._

This issue was introduced in the recent commit dc0ef88ae44d9e5 when `$upload.http` method was added

This pull request fixes the issue by just initializing the `config.headers` to empty object in upload function definition

```
config.headers = config.headers || {};
```
