### PR TITLE
Issue-#146: Allow option to send flat file.

### DIFF
--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -71,6 +71,10 @@ angularFileUpload.service('$upload', ['$http', '$rootScope', '$timeout', functio
 		config.headers = config.headers || {};
 		config.headers['Content-Type'] = undefined;
 		config.transformRequest = config.transformRequest || $http.defaults.transformRequest;
+		if (config.flatData) {
+			config.data = config.file;
+			return sendHttp(config);
+		}
 		var formData = new FormData();
 		if (config.data) {
 			for (var key in config.data) {


### PR DESCRIPTION
This change allows a user to pass a property of 'flatData: true'
to $upload.upload config which will skip the form data encoding and
send config.file as config.data.
