### PR TITLE
Allow xhr "retry"

### DIFF
--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -21,6 +21,7 @@ angularFileUpload.service('$upload', ['$http', '$timeout', function($http, $time
 		if (window.XMLHttpRequest.__isShim) {
 			config.headers['__setXHR_'] = function() {
 				return function(xhr) {
+					if ( ! xhr) return;
 					config.__XHR = xhr;
 					config.xhrFn && config.xhrFn(xhr);
 					xhr.upload.addEventListener('progress', function(e) {


### PR DESCRIPTION
When working with interceptors for authentication (http 401 -> re-authentication -> retry), on the "retry" call, the '__setXHR_' header function has no wrapper anymore. 
In this case, there is no 'xhr' argument since the function is called directly by angular. 
Therefore, that function should not be executed (which is not a problem since the events listeners have already been added).
