### PR TITLE
stopPropagation() for ng-file-drop to work when $document drop is disabled

### DIFF
--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -213,6 +213,7 @@ angularFileUpload.directive('ngFileDrop', [ '$parse', '$timeout', '$location', f
 		if ('draggable' in document.createElement('span')) {
 			var leaveTimeout = null;
 			elem[0].addEventListener("dragover", function(evt) {
+        evt.stopPropagation();
 				evt.preventDefault();
 				$timeout.cancel(leaveTimeout);
 				if (!elem[0].__drag_over_class_) {


### PR DESCRIPTION
I use this to prevent browser from opening file/folder preview when dropped (and navigating you away from the page)

``` javascript
 $document.bind('dragenter', function (e) {
    e.stopPropagation();
    e.preventDefault();
    var dt = e.dataTransfer;
    dt.effectAllowed = dt.dropEffect = 'none';
  });
  $document.bind('dragover', function (e) {
    e.stopPropagation();
    e.preventDefault();
    var dt = e.dataTransfer;
    dt.effectAllowed = dt.dropEffect = 'none';
  });
```

however it prevents ng-file-drop from working as well. Unless you add stopPropagation on the 'dragover' event.
