### PR TITLE
Set tabindex to -1 on hidden file input

### DIFF
--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -155,6 +155,7 @@ angularFileUpload.directive('ngFileSelect', [ '$parse', '$timeout', function($pa
 			fileElem.css("width", "1px").css("height", "1px").css("opacity", 0).css("position", "absolute").css('filter', 'alpha(opacity=0)')
 					.css("padding", 0).css("margin", 0).css("overflow", "hidden");
 			fileElem.attr('__wrapper_for_parent_', true);
+			fileElem.attr('tabindex', '-1');
 
 //			fileElem.css("top", 0).css("bottom", 0).css("left", 0).css("right", 0).css("width", "100%").
 //					css("opacity", 0).css("position", "absolute").css('filter', 'alpha(opacity=0)').css("padding", 0).css("margin", 0);


### PR DESCRIPTION
I like using the ng-file-select on regular buttons as it makes my forms cleaner and more customisable, however the tabbing is disrupted by the hidden file input.  Disabling the tab focus by setting tabindex to -1 makes my forms easier to use.
