### PR TITLE
fix(readme): change ng-file-model to ng-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ HTML:
   Syntax: 
 
 <button|div|input type="file"|ng-file-select|...
-    ng-file-select ng-file-model="myFiles" // binds the selected files to the scope model
+    ng-file-select ng-model="myFiles" // binds the selected files to the scope model
     ng-file-change="fileSelected($files, $event)" // will be called upon files being selected
                                                   // you can use $scope.$watch('myFiles') instead
     ng-multiple="true|false" // default false, allows selecting multiple files
@@ -54,7 +54,7 @@ HTML:
 >Upload</button>
 
 <div|button|ng-file-drop|...
-    ng-file-drop ng-file-model="myFiles" // binds the dropped files to the scope model    
+    ng-file-drop ng-model="myFiles" // binds the dropped files to the scope model
     ng-file-change="fileDropped($files, $event, $rejectedFiles)" //called upon files being dropped
     ng-multiple="true|false" // default false, allows selecting multiple files. 
     accept="image/*" // wildcard filter for file types allowed for drop (comma separated)


### PR DESCRIPTION
After trying to get a file-upload working I found out that `ng-file-model` is not used in combination with a `ng-file-select` and `ng-file-drop`. Instead, `ng-model` is used ([ng-file-select](https://github.com/danialfarid/angular-file-upload/blob/master/dist/angular-file-upload.js#L168) and [ng-file-drop](https://github.com/danialfarid/angular-file-upload/blob/master/dist/angular-file-upload.js#L252)). 

This PR fixes the examples in `README.md`.
