### PR TITLE
Put the dropAvailable attr in the scope as documented

### DIFF
--- a/demo/war/js/angular-file-upload.js
+++ b/demo/war/js/angular-file-upload.js
@@ -309,7 +309,7 @@ function handleDrop(scope, elem, attr, ngModel, $parse, $timeout, $location) {
 	var available = dropAvailable();
 	if (attr['dropAvailable']) {
 		$timeout(function() {
-			scope.dropAvailable ? scope.dropAvailable.value = available : scope.dropAvailable = available;
+			scope[attr.dropAvailable] ? scope[attr.dropAvailable].value = available : scope[attr.dropAvailable] = available;
 		});
 	}
 	if (!available) {


### PR DESCRIPTION
The readme implies `drop-available="dropSupported"` will cause `scope.dropSupported` to be set as a boolean, but `scope.dropAvailable` gets set instead. This fixes that, if that was the intention.