### PR TITLE
Prevent the handlers from being bound more than once.

### DIFF
--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -232,7 +232,7 @@ function linkFileSelect(scope, elem, attr, ngModel, $parse, $timeout, $compile) 
         if (attr.ngCapture) fileElem.attr('capture', $parse(attr.ngCapture)(scope));
         if (attr.ngDisabled) fileElem.attr('disabled', $parse(attr.ngDisabled)(scope));
 
-        fileElem.bind('change', changeFn);
+        fileElem.unbind('change', changeFn).bind('change', changeFn);
     }
 
     function createFileInput(evt) {
@@ -277,7 +277,7 @@ function linkFileSelect(scope, elem, attr, ngModel, $parse, $timeout, $compile) 
             fileElem[0].click();
         }
         if (isInputTypeFile()) {
-            elem.bind('click', clickHandler);
+            elem.unbind('click', clickHandler).bind('click', clickHandler);
             evt.preventDefault()
         }
     }
@@ -285,7 +285,7 @@ function linkFileSelect(scope, elem, attr, ngModel, $parse, $timeout, $compile) 
     if (window.FileAPI && window.FileAPI.ngfFixIE) {
         window.FileAPI.ngfFixIE(elem, createFileInput, changeFn, resetModel);
     } else {
-        elem.bind('click', clickHandler);
+        elem.unbind('click', clickHandler).bind('click', clickHandler);
     }
 }
 


### PR DESCRIPTION
I ran into an issue where the event handlers were bound multiple times causing the angular model to be reset to null after a file has been selected.  The added 'unbind' prevents a handler from being registered more than once.  Let me know if you'd like a a sample fiddle/plunkr.

