### PR TITLE
Prevent type='file' from being overwritten

### DIFF
--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -243,7 +243,9 @@ function linkFileSelect(scope, elem, attr, ngModel, $parse, $timeout, $compile) 
 
         for (var i = 0; i < elem[0].attributes.length; i++) {
             var attribute = elem[0].attributes[i];
-            fileElem.attr(attribute.name, attribute.value);
+            if (attribute.name !== "type") {
+				fileElem.attr(attribute.name, attribute.value);
+			}
         }
 
         if (isInputTypeFile()) {


### PR DESCRIPTION
if you have:

    <button type='button" ng-file-select>upload some files</button>

this will prevent the created `<input type='file` />` element from having it's `type` attribute overwritten.