### PR TITLE
JSON.stringify turns null values to strings.

### DIFF
--- a/dist/angular-file-upload.js
+++ b/dist/angular-file-upload.js
@@ -148,7 +148,7 @@ angularFileUpload.service('$upload', ['$http', '$q', '$timeout', function ($http
                                 if (config.sendObjectsAsJsonBlob && typeof val === 'object') {
                                     formData.append(key, new Blob([val], {type: 'application/json'}));
                                 } else {
-                                    formData.append(key, JSON.stringify(val));
+                                    formData.append(key, (null === val ? null : JSON.stringify(val)));
                                 }
                             }
 


### PR DESCRIPTION
Later, when parsing the data through the $_POST PHP object, "fields" properties that had null values turns to "null" string.