### PR TITLE
ngf-src should take advantage of the URL.createObjectURL for greater …

### DIFF
--- a/dist/ng-file-upload.js
+++ b/dist/ng-file-upload.js
@@ -525,6 +525,13 @@ ngFileUpload.directive('ngfSrc', ['$parse', '$timeout', function ($parse, $timeo
 							(!window.FileAPI || navigator.userAgent.indexOf('MSIE 8') === -1 || file.size < 20000) && 
 							(!window.FileAPI || navigator.userAgent.indexOf('MSIE 9') === -1 || file.size < 4000000)) {
 						$timeout(function() {
+							//prefer URL.createObjectURL for handling refrences to files of all sizes
+							//since it doesn´t build a large string in memory
+							var url = window.URL || window.webkitURL;
+							if(url && url.createObjectURL){
+								elem.attr('src', url.createObjectURL(file));
+								return;
+							}
 							var fileReader = new FileReader();
 							fileReader.readAsDataURL(file);
 							fileReader.onload = function(e) {


### PR DESCRIPTION
…mobile browser support

using URL.createObjectURL permits previewing large files on device that support it and improves
the preview speed.

URL.createObjectURL is currently supported by major mobile web browsers.
Without it, trying to preview some video files mostly crashes on mobile web browser.

```javascript
var url = window.URL || window.webkitURL;
if(url && url.createObjectURL){
	elem.attr('src', url.createObjectURL(file));
	return;
}
```