### PR TITLE
Strange issue on android bind click touchend being fired twice

### DIFF
--- a/demo/war/js/ng-file-upload-all.js
+++ b/demo/war/js/ng-file-upload-all.js
@@ -274,6 +274,7 @@ function linkFileSelect(scope, elem, attr, ngModel, $parse, $timeout, $compile) 
     }
 
     function clickHandler(evt) {
+    	evt.stopPropagation();
     	evt.preventDefault();
         var fileElem = createFileInput(evt);
         if (fileElem) {

--- a/demo/war/js/ng-file-upload.js
+++ b/demo/war/js/ng-file-upload.js
@@ -274,6 +274,7 @@ function linkFileSelect(scope, elem, attr, ngModel, $parse, $timeout, $compile) 
     }
 
     function clickHandler(evt) {
+    	evt.stopPropagation();
     	evt.preventDefault();
         var fileElem = createFileInput(evt);
         if (fileElem) {

--- a/dist/ng-file-upload-all.js
+++ b/dist/ng-file-upload-all.js
@@ -274,6 +274,7 @@ function linkFileSelect(scope, elem, attr, ngModel, $parse, $timeout, $compile) 
     }
 
     function clickHandler(evt) {
+    	evt.stopPropagation();
     	evt.preventDefault();
         var fileElem = createFileInput(evt);
         if (fileElem) {

--- a/dist/ng-file-upload.js
+++ b/dist/ng-file-upload.js
@@ -274,6 +274,7 @@ function linkFileSelect(scope, elem, attr, ngModel, $parse, $timeout, $compile) 
     }
 
     function clickHandler(evt) {
+    	evt.stopPropagation();
     	evt.preventDefault();
         var fileElem = createFileInput(evt);
         if (fileElem) {


### PR DESCRIPTION
Hi @danialfarid 

Thanks for your angular plugin. I encountered an issue in chrome 42.0.2311.11 in my Samsung Zoom K, when using the "ngf-select", the camera dialog would be triggered twice.
I think the scenario is very similar to
http://stackoverflow.com/questions/25572070/javascript-touchend-versus-click-dilemma
After applying the the fix, it works for me.

But I didn't find anyone with similar issues yet and your demo page https://angular-file-upload.appspot.com/ has no issue for me. I'm currently using this fix, but I just want to open this PR up to see if anyone has similar issues. If you know what might cause this, please kindly let me know. Thanks.
