### PR TITLE
Using usual forms request form for fields

### DIFF
--- a/demo/war/js/ng-file-upload.js
+++ b/demo/war/js/ng-file-upload.js
@@ -115,6 +115,31 @@ ngFileUpload.service('Upload', ['$http', '$q', '$timeout', function ($http, $q, 
         return promise;
     }
 
+    function addFormData(root, lastKey, formData) {
+        if(angular.isDate(root)) {
+          return formData.append(lastKey, root.toISOString());
+        }
+        if(angular.isString(root) || angular.isNumber(root)) {
+          return formData.append(lastKey, root);
+        }
+        if(angular.isObject(root)) {
+          for(key in root) {
+            if(root.hasOwnProperty(key)) {
+              var val = root[key];
+              getData(val, lastKey + '[' + key + ']', formData);
+            }
+          }
+          return ;
+        }
+        if(angular.isArray(root)) {
+          for(var i=0; i < root.length; i++) {
+            getData(root[i], lastKey + '[' + i + ']', formData);
+          }
+          return ;
+        }
+        formData.append(lastKey, JSON.stringify(root));
+    }
+
     this.upload = function (config) {
         config.headers = config.headers || {};
         config.headers['Content-Type'] = undefined;
@@ -150,6 +175,8 @@ ngFileUpload.service('Upload', ['$http', '$q', '$timeout', function ($http, $q, 
                             } else {
                                 if (config.sendObjectsAsJsonBlob && angular.isObject(val)) {
                                     formData.append(key, new Blob([val], {type: 'application/json'}));
+                                } else if (config.sendFieldsAsFormValue && (angular.isArray(val) || angular.isObject(val))) {
+                                    addFormData(val, key, formData);
                                 } else {
                                     formData.append(key, JSON.stringify(val));
                                 }


### PR DESCRIPTION
Added a new config option called `sendFieldsAsFormValue` that when it's `true`, it changes how the form data is send. The config option was created to ensure backward compatibility.

This change helps whoever uses PHP as a Backend, since it's the way PHP understand form fields.

When there's a field that is an array or object, it changes the key, appending each property of the object wrapped in brackets and each key of the array, also wrapped in brackets and making this key equal to the corresponding value at the object/array. 

This is a proposal, it's not finished or fully tested.

## Examples: Array

```javascript
fields: {
  tags: [ 'tagA', 'tagB', 'tagC' ]
}
```

The request would be (I'm using query string syntax, but its the
key/value form of multipart/form-data):

```
tags[]=tagA&tags[]=tagB&tags[]=tagC
```

## Examples: Object

The same works for objects:

```javascript
fields: {
  user: {
    name: 'John Doe'
    email: 'john@doe.org'
  }
}
```
The request would be (also like query string):

```
user[name]=John Doe&user[email]=john@doe.org
```

## Examples: Objects inside Array

If the request is an array of multiple objects:

```javascript`
fields: {
  users: [
    { email: 'user1@example.org' },
    { email: 'user2@example.org' }
  ]
}
```

The request:

```
users[0][email]=user1@example.org&users[1][email]=user2@example.org
```
