### PR TITLE
Fix for offset calculating in IE

### DIFF
--- a/src/shim-elem.js
+++ b/src/shim-elem.js
@@ -18,12 +18,16 @@
   }
 
   function getOffset(obj) {
-    var left, top;
-    left = top = 0;
+    var left = 0, top = 0;
+
+    if (window.jQuery) {
+      return jQuery(obj).offset();
+    }
+
     if (obj.offsetParent) {
       do {
-        left += obj.offsetLeft;
-        top += obj.offsetTop;
+        left += (obj.offsetLeft - obj.scrollLeft);
+        top += (obj.offsetTop - obj.scrollTop);
         obj = obj.offsetParent;
       } while (obj);
     }


### PR DESCRIPTION
Current implementation of offset calculating ignores scroll position, so I made fix and add check for using jq.offset func if aviable. Also you can use el.getBoundingClientRect() if support of IE8 don't needed. 