### PR TITLE
Fixes regex pattern for detecting Android

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -160,11 +160,10 @@
   }
 
   function isAndroidBelow44() {
-    var match = navigator.userAgent.toLowerCase().match(/android[^\d]*(\d|.)/);
-    if (match) {
-      var version = match[0].split('.');
-      return version[0] < '4' || (version[0] === '4' && version[1] < '4');
+    if (/Android[\s](\d+)\.(\d+)/.test(navigator.userAgent)) { //test for Android x.x (ignoring remaining digits);
+      return (Number(RegExp.$1 + RegExp.$2) < 44);
     }
+
     return false;
   }
 


### PR DESCRIPTION
Fixes regex pattern for detecting Android browser. 

Current pattern matches only first digit (i.e 'Android 10.1' will be  detected as version 1 .. not 10. Minor version will not be picked at all ).

According to http://www.useragentstring.com/pages/Android%20Webkit%20Browser/ 
UA string is always 'Android{space}x.x[.x]' so it's not necessary to convert the string to lower case.

Regards