### PR TITLE
Fix when config.file is not a file object or array

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -176,8 +176,10 @@ ngFileUpload.service('Upload', ['$http', '$q', '$timeout', function ($http, $q, 
             formData.append(isFileFormNameString ? fileFormName : fileFormName[i], config.file[i],
               (config.fileName && config.fileName[i]) || config.file[i].name);
           }
-        } else {
+        } else if (Object.prototype.toString.call(config.file) === '[object File]') {
           formData.append(fileFormName, config.file, config.fileName || config.file.name);
+        } else {
+          formData.append(fileFormName, JSON.stringify(config.file));
         }
       }
       return formData;


### PR DESCRIPTION
*A simple [plunkr](http://plnkr.co/edit/KCDHLAZVDsFFi7M6aFpn?p=preview) of the issue I'm describing. Test on Firefox.*

Imagine you have a Post model in your server and it has a Attachment. You have created a Post with an attachment and you want to edit it. The server sends following JSON:

```json
{
  "title": "Test",
  "content": "something",
  "attachment": {
    "path": "/path/to/attachment.js"
  }
}
```

If you don't change the attachment and send a PUT request via ng-file-upload, on Firefox you'll receive an error (Like this [plunkr](http://plnkr.co/edit/KCDHLAZVDsFFi7M6aFpn?p=preview)):

```js
Error: Argument 2 of FormData.append does not implement interface Blob.
```

Because (as [MDN describes](https://developer.mozilla.org/en-US/docs/Web/API/FormData/append)) `formData.append` only gets third value, `filename`, only if the second value is either a `File` or `Blob`. This causes Firefox to raise an error on [line 180](https://github.com/danialfarid/ng-file-upload/blob/master/src/upload.js#L180) and request won't be sent.

On Chrome, it sends a `null` value for `attachment`, so on the server the file will be deleted (in my case at least).

So I changed the lines 173-182 this way:

```js
if (angular.isArray(config.file)) {
  var isFileFormNameString = angular.isString(fileFormName);
  for (var i = 0; i < config.file.length; i++) {
    formData.append(isFileFormNameString ? fileFormName : fileFormName[i], config.file[i],
      (config.fileName && config.fileName[i]) || config.file[i].name);
  }
} else if (Object.prototype.toString.call(config.file) === '[object File]') {
  formData.append(fileFormName, config.file, config.fileName || config.file.name);
} else {
  formData.append(fileFormName, JSON.stringify(config.file));
}
```
It checks if the the `config.file` is a `File` object or not. same thing can be done for `Blob`. But I'm not sure if it's needed or not.