### PR TITLE
update README with reference to Rails integration blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,8 @@ You can find the sample server code in Java/GAE [here](https://github.com/danial
 [Wiki Sample](https://github.com/danialfarid/ng-file-upload/wiki/node.js-example) provided by [chovy](https://github.com/chovy).
 [Another wiki](https://github.com/danialfarid/ng-file-upload/wiki/Node-example) using Express 4.0 and the Multiparty provided by [Jonathan White](https://github.com/JonathanZWhite)
 * <a name="rails"></a>**Rails**
-[Wiki Sample](https://github.com/danialfarid/ng-file-upload/wiki/Rails-Example) provided by [guptapriyank](https://github.com/guptapriyank)
+[Wiki Sample](https://github.com/danialfarid/ng-file-upload/wiki/Rails-Example) provided by [guptapriyank](https://github.com/guptapriyank). [Blog post](http://www.coshx.com/blog/2015/07/10/file-attachments-in-angular/)
+provided by [Coshx Labs](http://www.coshx.com/).
 **Rails progress event**: If your server is Rails and Apache you may need to modify server configurations for the server to support upload progress. See [#207](https://github.com/danialfarid/ng-file-upload/issues/207)
 * <a name="php"></a>**PHP**
 [Wiki Sample] (https://github.com/danialfarid/ng-file-upload/wiki/PHP-Example) and related issue [only one file in $_FILES when uploading multiple files] (https://github.com/danialfarid/ng-file-upload/issues/475)


### PR DESCRIPTION
I wrote a blog post about using ng-file-upload with Rails 4, Paperclip, and S3. I thought it might be a useful guide, and I benefited from some of the other great resources in the README. 