### PR TITLE
fix ngfDrop detection of '$files' presence

### DIFF
--- a/src/drop.js
+++ b/src/drop.js
@@ -52,7 +52,7 @@
     }
 
     var disabled = false;
-    if (getAttr(attr, 'ngfDrop').search(/\W+$files\W+/) === -1) {
+    if (getAttr(attr, 'ngfDrop').search(/\W+\$files\W+/) === -1) {
       scope.$watch(getAttr(attr, 'ngfDrop'), function(val) {
         disabled = val === false;
       });


### PR DESCRIPTION
ngfDrop regular expression used to detect presence of '$files' string in handler was incorrect: '$' sign should be escaped otherwise it means end of string