### PR TITLE
allow a custom validate function separate from ngf-accept

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ app.controller('MyCtrl', ['$scope', 'Upload', function ($scope, Upload) {
   ngf-capture="'camera'" or "'other'" // allows mobile devices to capture using camera
   accept="image/*" // see standard HTML file input accept attribute
   ngf-accept="'image/*'" or "validate($file)" // function or comma separated wildcard to filter files allowed
+  nfg-validate="validate($file)" //function to provide custom validation
   ngf-min-size='10' // minimum acceptable file size in bytes
   ngf-max-size='10' // maximum acceptable file size in bytes
   ngf-keep="true" or "false" // default false, keep the previous ng-model files and append the new files
@@ -147,6 +148,7 @@ All attributes are optional except ngf-drop and one of ng-model or ngf-change.
   ngf-change="fileDropped($files, $file, $event, $rejectedFiles)" //called when files being dropped
   ngf-multiple="true" or "false" // default false, allows selecting multiple files. 
   ngf-accept="'.pdf,.jpg'" or "validate($file)" // function or comma separated wildcard to filter files allowed
+  nfg-validate="validate($file)" //function to provide custom validation
   ngf-allow-dir="true" or "false" // default true, allow dropping files only for Chrome webkit browser
   ngf-drag-over-class="{accept:'acceptClass', reject:'rejectClass', delay:100}" or "myDragOverClass" or
                     "calcDragOverClass($event)" 

--- a/src/select.js
+++ b/src/select.js
@@ -234,9 +234,13 @@
       return result;
     }
 
+    var custom = $parse(getAttr(attr, 'ngfValidate'))(scope, {$file: file, $event: evt});
     var accept = $parse(getAttr(attr, 'ngfAccept'))(scope, {$file: file, $event: evt});
     var fileSizeMax = $parse(getAttr(attr, 'ngfMaxSize'))(scope, {$file: file, $event: evt}) || 9007199254740991;
     var fileSizeMin = $parse(getAttr(attr, 'ngfMinSize'))(scope, {$file: file, $event: evt}) || -1;
+    if (custom === false) {
+      return false;
+    }
     if (accept != null && angular.isString(accept)) {
       var regexp = new RegExp(globStringToRegex(accept), 'gi');
       accept = (file.type != null && regexp.test(file.type.toLowerCase())) ||


### PR DESCRIPTION
This adds a new attribute "ngf-validate" for custom validation when files are added.  I found it somewhat limiting to use a custom function on the ngf-accept attribute because it disables the built in file type checking.  In my case, I have requirements to not allow certain characters in the file name as well as restrict certain file types.  If I use ngf-accept with a validation function it means I have to implement all the file type checking code to validate file type and check for invalid characters in the file name.  Using a separate attribute allows using the existing code to validate file types and also provide additional validation.

If you like this change, you might consider removing the custom validation function option on the accept tag as it is a little confusing to have both.  To avoid a breaking change, you could probably leave the functionality and just remove the documentation.

Thanks for a great component!