### PR TITLE
Use angular.toJson() instead of JSON.stringfy()

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -132,7 +132,7 @@ ngFileUpload.service('UploadBase', ['$http', '$q', '$timeout', function ($http, 
             formData.append(key, val);
           }
         } else {
-          val = angular.isString(val) ? val : JSON.stringify(val);
+          val = angular.isString(val) ? val : angular.toJson(val);
           if (config.sendFieldsAs === 'json-blob') {
             formData.append(key, new Blob([val], {type: 'application/json'}));
           } else {


### PR DESCRIPTION
Angular creates fields to keep track of changes angular.toJson()
ignores internal-use fields.

http://stackoverflow.com/questions/18826320/what-is-the-hashkey-added-to
-my-json-stringify-result