### PR TITLE
Check err type before run err.indexOf method

### DIFF
--- a/src/shim-upload.js
+++ b/src/shim-upload.js
@@ -97,7 +97,8 @@
             jsonp: false, //removes the callback form param
             cache: true, //removes the ?fileapiXXX in the url
             complete: function (err, fileApiXHR) {
-              if (err.indexOf('#2174') !== -1) {
+              // err can be boolean false
+              if (err && typeof err.indexOf === 'function' && err.indexOf('#2174') !== -1) {
                 // this error seems to be fine the file is being uploaded properly.
                 err = null;
               }


### PR DESCRIPTION
Issue occurs in IE9. ( I didn't check ie8)
Basically if  err is boolean false script crash with message: 
"Uncaught TypeError: err.indexOf is not a function"