### PR TITLE
Fix validating missing file type

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -247,7 +247,7 @@ ngFileUpload.service('UploadValidate', ['UploadDataUrl', '$q', '$timeout', funct
 
     validateAsync('validateAsyncFn', function () {
       return null;
-    }, /./, function (file, val) {
+    }, /.?/, function (file, val) {
       return val;
     }, function (r) {
       return r === true || r === null || r === '';


### PR DESCRIPTION
On Windows the file type for some files can't be guessed and the file.type property is set to the empty string.  This patch fixes the regex so that the validation functions will still be run.