### PR TITLE
Add general chunk size and total number of chunks as extra fields

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -219,8 +219,10 @@ ngFileUpload.service('UploadBase', ['$http', '$q', '$timeout', function ($http, 
         slice.name = file.name;
         slice.ngfName = file.ngfName;
         if (config._chunkSize) {
+          formData.append('_generalChunkSize', config._chunkSize);
           formData.append('_chunkSize', config._end - config._start);
           formData.append('_chunkNumber', Math.floor(config._start / config._chunkSize));
+          formData.append('_totalChunks', Math.ceil(config._file.size / config._chunkSize);
           formData.append('_totalSize', config._file.size);
         }
         return slice;


### PR DESCRIPTION
It is not always easy to work out the chunks on the servers-side. With those additional fields, reassemble the chunks becomes very easy from the server-side.