### PR TITLE
Dont return `false` for `ngfSelectDisabled` attribute.

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -101,7 +101,8 @@ ngFileUpload.directive('ngfSelect', ['$parse', '$timeout', '$compile', 'Upload',
     var initialTouchStartY = 0;
 
     function clickHandler(evt) {
-      if (elem.attr('disabled') || attrGetter('ngfSelectDisabled', scope)) return false;
+      if (elem.attr('disabled')) return false;
+      if (attrGetter('ngfSelectDisabled', scope)) return;
 
       var r = handleTouch(evt);
       if (r != null) return r;


### PR DESCRIPTION
jQuery treats `return false;` as `preventDefault` and `stopPropagation`.