### PR TITLE
Uses prototype checking instead of creating instance

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -30,7 +30,7 @@ ngFileUpload.service('UploadBase', ['$http', '$q', '$timeout', function ($http, 
   upload.promisesCount = 0;
 
   this.isResumeSupported = function () {
-    return window.Blob && (window.Blob instanceof Function) && new window.Blob().slice;
+    return window.Blob && (window.Blob instanceof Function) && window.Blob.prototype.slice;
   };
 
   var resumeSupported = this.isResumeSupported();


### PR DESCRIPTION
I use ngFileUpload in a current project and after reading the code a bit today, I noticed that it creates a new instance of Blob just to check if the slice method is defined.

Creating a Blob instance is very expensive for checking if it has the property. [Check this benchmark](http://jsperf.com/duck-typing-instance-vs-prototype)