### PR TITLE
Added Supporter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Issue Stats](http://issuestats.com/github/danialfarid/ng-file-upload/badge/issue)](http://issuestats.com/github/danialfarid/ng-file-upload)<br/>
 [![PayPayl donate button](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=danial%2efarid%40gmail%2ecom&lc=CA&item_name=ng%2dfile%2dupload&item_number=ng%2dfile%2dupload&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)
 [![Gratipay donate button](https://img.shields.io/gratipay/danialfarid.svg?label=donate)](https://gratipay.com/ng-file-upload/)
+[![Support](https://supporter.60devs.com/api/b/dz8c76aw7t6zm4bjbs995fx00/ng-file-upload)](https://supporter.60devs.com/support/dz8c76aw7t6zm4bjbs995fx00/ng-file-upload)
 
 ng-file-upload
 ===================


### PR DESCRIPTION
Hi @danialfarid 

I am a co-creator of Supporter, a service that helps open source projects accept donations, and I would like to invite you to join the service. This PR adds a badge similar to the ones you already have but I hope our badge will be more helpful. The badge leads to an enhanced payment page which allows defining the projects goals, choosing between one-time payments and the regular support. The badge also reflects how well the project is supported based on the project goals. Well, currently the payment form is also built on top of PayPal but we are looking forward to replace it with a better alternative. 

Also it's possible to have a personal payment page which more simple and that has a badge like this (text is editable):

[![Support](https://supporter.60devs.com/api/b/dz8c76aw7t6zm4bjbs995fx00/)](https://supporter.60devs.com/give/dz8c76aw7t6zm4bjbs995fx00)

You can start accepting payments via these badges if you sign in at our website using your Github account and define your PayPal email address. Before that the payment pages will not work.

If you happen not to like the idea of adding the badge or if you have other concerns, simply close the PR and I will remove the project badge from our website.

Looking forward to get your feedback,
Oleksii