### PR TITLE
Fix end parameter in resumeSize promise

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -132,6 +132,9 @@ ngFileUpload.service('UploadBase', ['$http', '$q', '$timeout', function ($http, 
     } else if (config.resumeSize) {
       config.resumeSize().then(function (size) {
         config._start = size;
+        if (config._chunkSize) {
+          config._end = config._start + config._chunkSize;
+        }
         uploadWithAngular();
       }, function (e) {
         throw e;


### PR DESCRIPTION
The end parameter is now calculated in case of resumeSize promise usage. Build of other files is required.