### PR TITLE
make sure the directoryname is not double

### DIFF
--- a/src/drop.js
+++ b/src/drop.js
@@ -226,7 +226,7 @@
             var promises = [upload.emptyPromise()];
             if (includeDir) {
               var file = {type: 'directory'};
-              file.name = file.path = (path || '') + entry.name + entry.name;
+              file.name = file.path = (path || '') + entry.name;
               files.push(file);
             }
             var dirReader = entry.createReader();


### PR DESCRIPTION
If you include directories, the name is doubled, so "abc" becomes "abcabc"