### PR TITLE
Fix "Uncaught TypeError: html.replace is not a function"

### DIFF
--- a/src/drop.js
+++ b/src/drop.js
@@ -163,7 +163,7 @@
     }
 
     function extractFilesFromHtml(updateOn, html) {
-      if (!upload.shouldUpdateOn(updateOn, attr, scope) || !html) return upload.rejectPromise([]);
+      if (!upload.shouldUpdateOn(updateOn, attr, scope) || typeof html !== 'string' ) return upload.rejectPromise([]);
       var urls = [];
       html.replace(/<(img src|img [^>]* src) *=\"([^\"]*)\"/gi, function (m, n, src) {
         urls.push(src);


### PR DESCRIPTION
For a file drop action instead of an html string,  a `DataTransfer` object is given:
- this happens for a form were the drop-zone is the whole form and the form contains a `contenteditable` element
- the user does a copy-paste inside that `contenteditable`
- using ckeditor to manage the `contenteditable`: http://docs.ckeditor.com/#!/api/CKEDITOR.plugins.clipboard.dataTransfer
