### PR TITLE
Add filename to file uploaded via drag'n'drop from other browser page

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -371,9 +371,11 @@ ngFileUpload.service('UploadBase', ['$http', '$q', '$timeout', function ($http, 
       var arrayBufferView = new Uint8Array(resp.data);
       var type = resp.headers('content-type') || 'image/WebP';
       var blob = new window.Blob([arrayBufferView], {type: type});
+      var matches = url.match(/.*\/(.+?)(\?.*)?$/);
+      if (matches.length > 1) {
+        blob.name = matches[1];
+      }
       defer.resolve(blob);
-      //var split = type.split('[/;]');
-      //blob.name = url.substring(0, 150).replace(/\W+/g, '') + '.' + (split.length > 1 ? split[1] : 'jpg');
     }, function (e) {
       defer.reject(e);
     });


### PR DESCRIPTION
This adds a filename to images that are uploaded via drag'n'drop from another browser page.
The filename is retrieved from the image's url.