### PR TITLE
only show drag over class from file system when ng-model-options updateOn can't set dropUrl

### DIFF
--- a/src/drop.js
+++ b/src/drop.js
@@ -188,24 +188,23 @@
 
     function calculateDragOverClass(scope, attr, evt, callback) {
       var obj = attrGetter('ngfDragOverClass', scope, {$event: evt}), dClass = 'dragover';
+      var items = getFileItems(evt);
+      if (!items || items.length === 0) {
+        return;
+      }
       if (angular.isString(obj)) {
         dClass = obj;
       } else if (obj) {
         if (obj.delay) dragOverDelay = obj.delay;
         if (obj.accept || obj.reject) {
-          var items = evt.dataTransfer.items;
-          if (items == null || !items.length) {
-            dClass = obj.accept;
-          } else {
-            var pattern = obj.pattern || attrGetter('ngfPattern', scope, {$event: evt});
-            var len = items.length;
-            while (len--) {
-              if (!upload.validatePattern(items[len], pattern)) {
-                dClass = obj.reject;
-                break;
-              } else {
-                dClass = obj.accept;
-              }
+          var pattern = obj.pattern || attrGetter('ngfPattern', scope, {$event: evt});
+          var len = items.length;
+          while (len--) {
+            if (!upload.validatePattern(items[len], pattern)) {
+              dClass = obj.reject;
+              break;
+            } else {
+              dClass = obj.accept;
             }
           }
         }
@@ -336,4 +335,15 @@
     return ('draggable' in div) && ('ondrop' in div) && !/Edge\/12./i.test(navigator.userAgent);
   }
 
+  function getFileItems(evt) {
+    var fileItems = [];
+    if (evt.dataTransfer.types && evt.dataTransfer.items) {
+      for (var i = 0; i < evt.dataTransfer.types.length; i++) {
+        if (evt.dataTransfer.types[i] === 'Files') {
+          fileItems.push(evt.dataTransfer.items[i]);
+        }
+      }
+    }
+    return fileItems;
+  }
 })();

--- a/src/drop.js
+++ b/src/drop.js
@@ -187,8 +187,13 @@
     }
 
     function calculateDragOverClass(scope, attr, evt, callback) {
-      var obj = attrGetter('ngfDragOverClass', scope, {$event: evt}), dClass = 'dragover';
-      var items = getFileItems(evt);
+      var obj = attrGetter('ngfDragOverClass', scope, {$event: evt}),
+          dClass = 'dragover',
+          types = ['Files'];
+      if(upload.shouldUpdateOn('dropUrl', attr, scope)){
+        types.push('text/html');
+      }
+      var items = getFileItems(evt, types);
       if (!items || items.length === 0) {
         return;
       }
@@ -335,11 +340,11 @@
     return ('draggable' in div) && ('ondrop' in div) && !/Edge\/12./i.test(navigator.userAgent);
   }
 
-  function getFileItems(evt) {
+  function getFileItems(evt, types) {
     var fileItems = [];
     if (evt.dataTransfer.types && evt.dataTransfer.items) {
       for (var i = 0; i < evt.dataTransfer.types.length; i++) {
-        if (evt.dataTransfer.types[i] === 'Files') {
+        if (types.indexOf(evt.dataTransfer.types[i]) > -1) {
           fileItems.push(evt.dataTransfer.items[i]);
         }
       }


### PR DESCRIPTION
only show drag over class from file system when ng-model-options updateOn can't set dropUrl,
new PR for https://github.com/danialfarid/ng-file-upload/pull/1497