### PR TITLE
avoid resizing if destination mimetype is image/svg+xml

### DIFF
--- a/src/resize.js
+++ b/src/resize.js
@@ -101,6 +101,7 @@ ngFileUpload.service('UploadResize', ['UploadValidate', '$q', function (UploadVa
 
   upload.resize = function (file, width, height, quality, type, ratio, centerCrop, resizeIf, restoreExif) {
     if (file.type.indexOf('image') !== 0) return upload.emptyPromise(file);
+    if ((type || file.type) === 'image/svg+xml') return upload.emptyPromise(file);
 
     var deferred = $q.defer();
     upload.dataUrl(file, true).then(function (url) {


### PR DESCRIPTION
Hi Danial,
Thank you for this module that is really helpfull. I'm using it in different project and today, I try to upload some images in svg format with it, and I had a bug in Firefox due to resizing, even if I do not need resizing for this project.

I try to set the resize-if attribute with `file.type !== 'image/svg+xml'` to skip resizing, but the bug was still there.

So I add this code to skip rezising when destination mimetype is svg (image/svg+xml)

Could you check that this is allright for you ?

Regards.
David