### PR TITLE
Exclude unnecessary folders from npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+demo/
+nuget/
+src/
+test/


### PR DESCRIPTION
NPM package is 3.9MB that is so big for production use. I added a .npmignore file to ignore folders that are unnecessary for production from npm. Only `dist` folder is enough for npm package