### PR TITLE
IE11 upload fix (resolves GitHub issues #1520 and #1597)

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -37,6 +37,8 @@ ngFileUpload.directive('ngfSelect', ['$parse', '$timeout', '$compile', 'Upload',
     function changeFn(evt) {
       if (upload.shouldUpdateOn('change', attr, scope)) {
         var fileList = evt.__files_ || (evt.target && evt.target.files), files = [];
+        /* Handle duplicate call in  IE11 */
+        if (!fileList) return;
         for (var i = 0; i < fileList.length; i++) {
           files.push(fileList[i]);
         }


### PR DESCRIPTION
Have added a simple null check for the changeFn() function call, which fixes file upload on select in Internet Explorer 11.

This should fix GitHub issues #1520 and #1597 , and possibly other issues related to the plugin not working in IE11 (and potentially other versions of IE.)