### PR TITLE
Replaced deprecated jquery functions

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -123,7 +123,7 @@ ngFileUpload.directive('ngfSelect', ['$parse', '$timeout', '$compile', 'Upload',
         if (!isInputTypeFile() && !document.body.contains(fileElem[0])) {
           generatedElems.push({el: elem, ref: fileElem.parent()});
           document.body.appendChild(fileElem.parent()[0]);
-          fileElem.bind('change', changeFn);
+          fileElem.on('change', changeFn);
         }
       } catch (e) {/*ignore*/
       }
@@ -179,12 +179,12 @@ ngFileUpload.directive('ngfSelect', ['$parse', '$timeout', '$compile', 'Upload',
     if (!isInputTypeFile()) {
       fileElem = createFileInput();
     }
-    fileElem.bind('change', changeFn);
+    fileElem.on('change', changeFn);
 
     if (!isInputTypeFile()) {
-      elem.bind('click touchstart touchend', clickHandler);
+      elem.on('click touchstart touchend', clickHandler);
     } else {
-      elem.bind('click', resetModel);
+      elem.on('click', resetModel);
     }
 
     function ie10SameFileSelectFix(evt) {
@@ -195,13 +195,13 @@ ngFileUpload.directive('ngfSelect', ['$parse', '$timeout', '$compile', 'Upload',
         }
         evt.preventDefault();
         evt.stopPropagation();
-        fileElem.unbind('click');
+        fileElem.off('click');
         var clone = fileElem.clone();
         fileElem.replaceWith(clone);
         fileElem = clone;
         fileElem.attr('__ngf_ie10_Fix_', 'true');
-        fileElem.bind('change', changeFn);
-        fileElem.bind('click', ie10SameFileSelectFix);
+        fileElem.on('change', changeFn);
+        fileElem.on('click', ie10SameFileSelectFix);
         fileElem[0].click();
         return false;
       } else {
@@ -210,7 +210,7 @@ ngFileUpload.directive('ngfSelect', ['$parse', '$timeout', '$compile', 'Upload',
     }
 
     if (navigator.appVersion.indexOf('MSIE 10') !== -1) {
-      fileElem.bind('click', ie10SameFileSelectFix);
+      fileElem.on('click', ie10SameFileSelectFix);
     }
 
     if (ngModel) ngModel.$formatters.push(function (val) {

--- a/src/shim-elem.js
+++ b/src/shim-elem.js
@@ -77,9 +77,9 @@
           if (label) label.removeClass('js-fileapi-wrapper');
         } else {
           if (!fileElem.attr('__ngf_flash_')) {
-            fileElem.unbind('change');
-            fileElem.unbind('click');
-            fileElem.bind('change', function (evt) {
+            fileElem.off('change');
+            fileElem.off('click');
+            fileElem.on('change', function (evt) {
               fileApiChangeFn.apply(this, [evt]);
               changeFn.apply(this, [evt]);
             });
@@ -99,7 +99,7 @@
         }
       };
 
-      elem.bind('mouseenter', fixInputStyle);
+      elem.on('mouseenter', fixInputStyle);
 
       var fileApiChangeFn = function (evt) {
         var files = FileAPI.getFiles(evt);


### PR DESCRIPTION
Since jQuery 3.0, both .bind() and .unbind() have been deprecated.
The suggested replacements are:
jquery.bind() => jquery.on()
jquery.unbind() => jquery.off()