### PR TITLE
Fix the issue that infinitely checking duration of video.

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -470,6 +470,7 @@ ngFileUpload.service('UploadValidate', ['UploadDataUrl', '$q', '$timeout', funct
         var count = 0;
 
         function checkLoadError() {
+          count++;
           $timeout(function () {
             if (el[0].parentNode) {
               if (el[0].duration) {


### PR DESCRIPTION
 The dynamical video tag can not be created in the embedded browser, uploading video would run into dead loop.