### PR TITLE
Additional IE11 select upload fix

### DIFF
--- a/dist/ng-file-upload.js
+++ b/dist/ng-file-upload.js
@@ -733,7 +733,7 @@ ngFileUpload.directive('ngfSelect', ['$parse', '$timeout', '$compile', 'Upload',
       if (upload.shouldUpdateOn('change', attr, scope)) {
         var fileList = evt.__files_ || (evt.target && evt.target.files), files = [];
         /* Handle duplicate call in  IE11 */
-        if (!fileList) return;
+        if (!fileList || fileList.length === 0) return;
         for (var i = 0; i < fileList.length; i++) {
           files.push(fileList[i]);
         }


### PR DESCRIPTION
ngf-select is triggering file change twice in IE11 and this is making my model null.
I know there was fix done in previous version by checking if the fileList is null in changeFn function but in my case, the list is not null but it was empty. This result in nullifying my file object.
