### PR TITLE
Support for empty arrays.

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -259,6 +259,9 @@ ngFileUpload.service('UploadBase', ['$http', '$q', '$timeout', function ($http, 
 
     function addFieldToFormData(formData, val, key) {
       if (val !== undefined) {
+        if(Array.isArray(val) && !val.length) {
+          return formData.append(key, '');
+        }
         if (angular.isDate(val)) {
           val = val.toISOString();
         }


### PR DESCRIPTION
If an empty array is specified within the `data` object passed to `Upload` the `addFieldToFormData` won't add anything to the resulting `formData`. There's cases where the server needs to know if the user for example wants to update an array in a db model, for example.

On the server side one can check if the receiving field was an empty array:

`if(!fields['skills'][0]) { // empty array }`

I'm not sure if there's a more simple or stright way of doing this, let me know you thoughts.