### PR TITLE
Update Readme: ngf-allow-dir browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ At least one of the `ngf-select` or `ngf-drop` are mandatory for the plugin to l
   *ngf-capture="'camera'" or "'other'" <!--  allows mobile devices to capture using camera -->
   *ngf-accept="'image/*'" <!--  standard HTML accept attr, browser specific select popup window -->
 
-  +ngf-allow-dir="boolean" <!--  default true, allow dropping files only for Chrome webkit browser -->
+  +ngf-allow-dir="boolean" <!--  default true, allow dropping of directories - files inside the directory are uploaded. Chrome / Firefox / Edge browsers only -->
   +ngf-include-dir="boolean" <!-- default false, include directories in the dropped file array.
     You can detect if they are directory or not by checking the type === 'directory'. -->
   +ngf-drag-over-class="{pattern: 'image/*', accept:'acceptClass', reject:'rejectClass', delay:100}"


### PR DESCRIPTION
Updated documentation for ngf-allow-dir attribute and browser compatibility as per:
https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry#Browser_compatibility