### PR TITLE
fix: remove elements appended to body in ngf-select on $destroy

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -227,17 +227,20 @@ ngFileUpload.directive('ngfSelect', ['$parse', '$timeout', '$compile', 'Upload',
       angular.forEach(unwatches, function (unwatch) {
         unwatch();
       });
+      cleanUpGeneratedElems();
     });
 
-    $timeout(function () {
-      for (var i = 0; i < generatedElems.length; i++) {
-        var g = generatedElems[i];
-        if (!document.body.contains(g.el[0])) {
-          generatedElems.splice(i, 1);
-          g.ref.remove();
+    function cleanUpGeneratedElems() {
+      $timeout(function () {
+        for (var i = 0; i < generatedElems.length; i++) {
+          var g = generatedElems[i];
+          if (!document.body.contains(g.el[0])) {
+            generatedElems.splice(i, 1);
+            g.ref.remove();
+          }
         }
-      }
-    });
+      });
+    }
 
     if (window.FileAPI && window.FileAPI.ngfFixIE) {
       window.FileAPI.ngfFixIE(elem, fileElem, changeFn);


### PR DESCRIPTION
If the directive is added to something other than a file input, it adds
file input elements to the document body. Since these are outside of the
element the directive is applied to, they aren't automatically removed at
the end of its life.

The cleanup code for these elements already existed, but it was only being called
once when the directive was first applied, and wasn't actually removing anything. Now it
will be called on $destroy, and the file elements are correctly removed